### PR TITLE
Changes to using a fixed version of client-go image.

### DIFF
--- a/geth-poa/Dockerfile
+++ b/geth-poa/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:latest
+FROM ethereum/client-go:v1.7.3
 
 RUN apk update \
     && apk add bash curl


### PR DESCRIPTION
The uncertainty introduced by using `latest` is not worth the benefit of constantly testing against latest version.