### PR TITLE
Update Dockerfile

### DIFF
--- a/geth-poa/Dockerfile
+++ b/geth-poa/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.7.3
+FROM ethereum/client-go:v1.8.1
 
 RUN apk update \
     && apk add bash curl


### PR DESCRIPTION
use newer base image to get newer version of alpine in order to get version of node and npm we need to deploy contracts in docker container.