### PR TITLE
use newly build base image 1.7.3.3 with newer version of alpine

### DIFF
--- a/geth-poa/Dockerfile
+++ b/geth-poa/Dockerfile
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.7.3
+FROM augurproject/go-ethereum:1.7.3.3
 
 RUN apk update \
     && apk add bash curl


### PR DESCRIPTION
updated base image for geth-poa to use newly created augurProject/go-ethereum version 1.7.3.3