### PR TITLE
use base image for geth v1.8.2

### DIFF
--- a/geth-poa/Dockerfile
+++ b/geth-poa/Dockerfile
@@ -1,4 +1,4 @@
-FROM augurproject/go-ethereum:1.7.3.3
+FROM ethereum/client-go:v1.8.2
 
 RUN apk update \
     && apk add bash curl


### PR DESCRIPTION
checked out geth v1.8.2 as base image and was able to upload contracts and run flash scripts.