### PR TITLE
fixed docker buffered output

### DIFF
--- a/geth-poa/common_start.sh
+++ b/geth-poa/common_start.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 declare -i NODE_PID
-declare -i TAIL_PID
 
 read -r -d INITIAL_TX_DATA << --EOF
 {
@@ -20,7 +19,7 @@ read -r -d INITIAL_TX_DATA << --EOF
 
 
 node_cleanup() {
-  kill $TAIL_PID $NODE_PID > /dev/null 2>&1
+  kill $NODE_PID > /dev/null 2>&1
 }
 
 node_wait() {

--- a/geth-poa/start.sh
+++ b/geth-poa/start.sh
@@ -21,11 +21,8 @@ node_start() {
     --verbosity ${GETH_VERBOSITY:-2} --mine \
     --ws --wsapi eth,net,web3,personal,txpool --wsaddr 0.0.0.0 --wsport $WSPORT --wsorigins '*' \
     --rpc --rpcapi eth,net,web3,personal,miner,txpool --rpcaddr 0.0.0.0 --rpcport $RPCPORT --rpccorsdomain '*' --rpcvhosts '*' \
-    --targetgaslimit 6500000 < /dev/null > $ROOT/geth.log 2>&1 &
+    --targetgaslimit 6500000 &
   NODE_PID=$!
-
-  tail -F $ROOT/geth.log 2>/dev/null &
-  TAIL_PID=$!
 }
 
 setup_chain_template() {


### PR DESCRIPTION
Writing to this file has caused buffering, so docker logs does not pick up on any output (at least, it will be significantly delayed).

I think writing to `geth.log` is more trouble than it is worth, since alpine doesn't come with any quick solutions, like `unbuffer`, `sed -u`, and `grep --line-buffered` 